### PR TITLE
Preserve active DefinitionRevisions

### DIFF
--- a/pkg/controller/core.oam.dev/v1beta1/core/revison.go
+++ b/pkg/controller/core.oam.dev/v1beta1/core/revison.go
@@ -35,7 +35,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	workflowv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/condition"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"

--- a/pkg/controller/core.oam.dev/v1beta1/core/revison.go
+++ b/pkg/controller/core.oam.dev/v1beta1/core/revison.go
@@ -35,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	workflowv1alpha1 "github.com/kubevela/workflow/api/v1alpha1"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/condition"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
@@ -387,6 +388,14 @@ func CleanUpDefinitionRevision(ctx context.Context, cli client.Client, def runti
 		if rev.Name == usingRevision.Name {
 			continue
 		}
+		used, err := isDefinitionRevisionUsed(ctx, cli, rev.Name)
+		if err != nil {
+			return err
+		}
+		if used {
+			klog.InfoS("skip deleting definitionRevision still in use", "name", rev.Name)
+			continue
+		}
 		if err := cli.Delete(ctx, rev.DeepCopy()); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -401,6 +410,39 @@ func (h historiesByRevision) Len() int      { return len(h) }
 func (h historiesByRevision) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
 func (h historiesByRevision) Less(i, j int) bool {
 	return h[i].Spec.Revision < h[j].Spec.Revision
+}
+
+// isDefinitionRevisionUsed checks whether a DefinitionRevision is referenced by any existing Application.
+func isDefinitionRevisionUsed(ctx context.Context, cli client.Client, revName string) (bool, error) {
+	appList := new(v1beta1.ApplicationList)
+	if err := cli.List(ctx, appList); err != nil {
+		return false, err
+	}
+	for _, app := range appList.Items {
+		for _, comp := range app.Spec.Components {
+			if n, err := util.ConvertDefinitionRevName(comp.Type); err == nil && n == revName {
+				return true, nil
+			}
+			for _, tr := range comp.Traits {
+				if n, err := util.ConvertDefinitionRevName(tr.Type); err == nil && n == revName {
+					return true, nil
+				}
+			}
+		}
+		for _, policy := range app.Spec.Policies {
+			if n, err := util.ConvertDefinitionRevName(policy.Type); err == nil && n == revName {
+				return true, nil
+			}
+		}
+		if app.Spec.Workflow != nil {
+			for _, step := range app.Spec.Workflow.Steps {
+				if n, err := util.ConvertDefinitionRevName(step.Type); err == nil && n == revName {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
 }
 
 // ReconcileDefinitionRevision generate the definition revision and update it.


### PR DESCRIPTION
## Summary
- avoid deleting DefinitionRevision referenced by applications
- add check for DefinitionRevision usage when pruning

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e69efda98832a847e593e1681a3a6