### PR TITLE
feat: defkit labels array outputs health switch

### DIFF
--- a/pkg/definition/defkit/base.go
+++ b/pkg/definition/defkit/base.go
@@ -44,6 +44,7 @@ type baseDefinition struct {
 	helperDefinitions []HelperDefinition
 	rawCUE            string
 	imports           []string
+	labels            map[string]string
 	// Placement constraints for cluster-aware definition deployment
 	runOn    []placement.Condition
 	notRunOn []placement.Condition
@@ -94,6 +95,24 @@ func (b *baseDefinition) setRawCUE(cue string) {
 // addImports adds CUE imports.
 func (b *baseDefinition) addImports(imports ...string) {
 	b.imports = append(b.imports, imports...)
+}
+
+// setLabel sets a single label key-value pair.
+func (b *baseDefinition) setLabel(key, value string) {
+	if b.labels == nil {
+		b.labels = make(map[string]string)
+	}
+	b.labels[key] = value
+}
+
+// setLabels sets multiple labels at once.
+func (b *baseDefinition) setLabels(labels map[string]string) {
+	if b.labels == nil {
+		b.labels = make(map[string]string)
+	}
+	for k, v := range labels {
+		b.labels[k] = v
+	}
 }
 
 // addRunOn adds placement conditions specifying where this definition should run.
@@ -151,6 +170,11 @@ func (b *baseDefinition) GetRawCUE() string {
 // GetImports returns the CUE imports.
 func (b *baseDefinition) GetImports() []string {
 	return b.imports
+}
+
+// GetLabels returns the definition labels.
+func (b *baseDefinition) GetLabels() map[string]string {
+	return b.labels
 }
 
 // HasTemplate returns true if the definition has a template function set.

--- a/pkg/definition/defkit/health_expr.go
+++ b/pkg/definition/defkit/health_expr.go
@@ -377,7 +377,7 @@ func (r *resourceTypeSwitchHealthExpr) BuildFull() string {
 		func(c resourceHealthCase) string {
 			preamble := c.expr.Preamble()
 			if preamble != "" {
-				return preamble + "\n\tisHealth: " + c.expr.ToCUE()
+				return preamble + "\nisHealth: " + c.expr.ToCUE()
 			}
 			return "isHealth: " + c.expr.ToCUE()
 		},

--- a/pkg/definition/defkit/param.go
+++ b/pkg/definition/defkit/param.go
@@ -801,6 +801,7 @@ type StructField struct {
 	nested       *StructParam // for nested structs
 	schemaRef    string       // reference to a helper definition (e.g., "HealthProbe")
 	enumValues   []string     // allowed enum values for string fields
+	schema       string       // raw CUE schema (e.g., "[string]: string")
 }
 
 // Field creates a new struct field definition.
@@ -863,6 +864,16 @@ func (f *StructField) GetDescription() string { return f.description }
 // GetNested returns the nested struct definition, if any.
 func (f *StructField) GetNested() *StructParam { return f.nested }
 
+// WithSchema sets a raw CUE schema for this field.
+// This allows specifying complex CUE types like "[string]: string".
+func (f *StructField) WithSchema(schema string) *StructField {
+	f.schema = schema
+	return f
+}
+
+// GetSchema returns the raw CUE schema for this field.
+func (f *StructField) GetSchema() string { return f.schema }
+
 // WithSchemaRef sets a reference to a helper type definition (e.g., "#RuleSelector").
 // This is used when the field type is defined elsewhere as a helper definition.
 func (f *StructField) WithSchemaRef(ref string) *StructField {
@@ -888,6 +899,7 @@ type StructParam struct {
 	baseParam
 	fields    []*StructField
 	schemaRef string // reference to a helper definition (e.g., "HealthProbe")
+	isOpen    bool   // when true, generates open struct with ... (allows extra fields)
 }
 
 // Struct creates a new struct parameter with the given name.
@@ -906,6 +918,16 @@ func (p *StructParam) Fields(fields ...*StructField) *StructParam {
 	p.fields = append(p.fields, fields...)
 	return p
 }
+
+// Open marks this struct as open (allows extra fields beyond those defined).
+// This generates CUE with `...` at the end of the struct body.
+func (p *StructParam) Open() *StructParam {
+	p.isOpen = true
+	return p
+}
+
+// IsOpen returns true if this struct allows extra fields.
+func (p *StructParam) IsOpen() bool { return p.isOpen }
 
 // Required marks the parameter as required.
 func (p *StructParam) Required() *StructParam {

--- a/pkg/definition/defkit/status_expr.go
+++ b/pkg/definition/defkit/status_expr.go
@@ -783,7 +783,7 @@ func (r *resourceTypeSwitchStatusExpr) BuildFull() string {
 		func(c resourceStatusCase) string {
 			preamble := c.expr.Preamble()
 			if preamble != "" {
-				return preamble + "\n\tmessage: " + c.expr.ToCUE()
+				return preamble + "\nmessage: " + c.expr.ToCUE()
 			}
 			return "message: " + c.expr.ToCUE()
 		},


### PR DESCRIPTION
### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dynamic labels, array-based outputs, and resource-type health/status switches in DefKit to make CUE templates more flexible and expressive.

- **New Features**
  - Labels: Set labels via ComponentDefinition.Label/Labels; CUE now emits labels under metadata.
  - Array outputs: Template.OutputPassthrough(param, index) and Template.OutputsForEach(param, prefix, startIndex) generate output/outputs from parameter arrays.
  - Health/Status switches: ResourceSwitch builders select expressions by apiVersion/kind with a default; includes DeploymentHealthExpr and DeploymentStatusExpr helpers.
  - Params: StructParam.Open() for open structs and StructField.WithSchema() for raw CUE schemas (e.g., “[string]: string”).
  - CUE generation: Support for labels, array passthrough/for-each outputs, open structs, and field-level raw schemas.

- **Bug Fixes**
  - Minor formatting adjustments in health and status expression outputs.

<sup>Written for commit d2642e8ba2eca691e74af698f7fb0b7df5693932. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added labels support for component definitions with a fluent API for easy attachment.
  * Introduced array output configurations enabling passthrough and per-item patterns.
  * Added resource-type based health and status policy generation with deployment-specific expressions.
  * Extended struct parameters with raw CUE schema support and open struct capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->