### PR TITLE
test: adds slsa generator to the workflow

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -1,4 +1,5 @@
 name: Registry
+
 on:
   push:
     branches:
@@ -12,11 +13,19 @@ permissions:
 
 jobs:
   publish-core-images:
+    name: Build and Push Vela Images
     permissions:
       packages: write
     runs-on: ubuntu-22.04
+    outputs:
+      vela_core_image: ${{ steps.meta-vela-core.outputs.image }}
+      vela_core_digest: ${{ steps.meta-vela-core.outputs.digest }}
+      vela_cli_image: ${{ steps.meta-vela-cli.outputs.image }}
+      vela_cli_digest: ${{ steps.meta-vela-cli.outputs.digest }}
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+
       - name: Get the version
         id: get_version
         run: |
@@ -25,34 +34,38 @@ jobs:
             VERSION=latest
           fi
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Get git revision
         id: vars
         shell: bash
         run: |
           echo "git_revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - name: Login ghcr.io
+
+      - name: Login to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login docker.io
+
+      - name: Login to DockerHub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
         with:
           driver-opts: image=moby/buildkit:master
 
       - uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-        name: Build & Pushing vela-core for Dockerhub, GHCR
+        name: Build & Push Vela Core for Dockerhub, GHCR
         with:
           context: .
           file: Dockerfile
-          labels: |-
+          labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
           platforms: linux/amd64,linux/arm64
@@ -61,16 +74,28 @@ jobs:
             GITVERSION=git-${{ steps.vars.outputs.git_revision }}
             VERSION=${{ steps.get_version.outputs.VERSION }}
             GOPROXY=https://proxy.golang.org
-          tags: |-
+          tags: |
             docker.io/oamdev/vela-core:${{ steps.get_version.outputs.VERSION }}
             ghcr.io/${{ github.repository_owner }}/oamdev/vela-core:${{ steps.get_version.outputs.VERSION }}
+      
+      - uses: imjasonh/setup-crane@v0.1
+        name: Installs Crane
+             
+      - name: Get Vela Core Image Digest
+        id: meta-vela-core
+        run: |
+          IMAGE=ghcr.io/${{ github.repository_owner }}/oamdev/vela-core
+          TAG=${{ steps.get_version.outputs.VERSION }}
+          DIGEST=$(crane digest $IMAGE:$TAG)
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-        name: Build & Pushing CLI for Dockerhub, GHCR
+        name: Build & Push Vela CLI for Dockerhub, GHCR
         with:
           context: .
           file: Dockerfile.cli
-          labels: |-
+          labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
           platforms: linux/amd64,linux/arm64
@@ -79,6 +104,49 @@ jobs:
             GITVERSION=git-${{ steps.vars.outputs.git_revision }}
             VERSION=${{ steps.get_version.outputs.VERSION }}
             GOPROXY=https://proxy.golang.org
-          tags: |-
+          tags: |
             docker.io/oamdev/vela-cli:${{ steps.get_version.outputs.VERSION }}
             ghcr.io/${{ github.repository_owner }}/oamdev/vela-cli:${{ steps.get_version.outputs.VERSION }}
+
+      - name: Get Vela CLI Image Digest
+        id: meta-vela-cli
+        run: |
+          IMAGE=ghcr.io/${{ github.repository_owner }}/oamdev/vela-cli
+          TAG=${{ steps.get_version.outputs.VERSION }}
+          DIGEST=$(crane digest $IMAGE:$TAG)
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
+  provenance-vela-core:
+    name: Generate Provenance for Vela Core
+    needs: publish-core-images
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # has to be sem var
+    with:
+      image: ${{ needs.publish-core-images.outputs.vela_core_image }}
+      digest: ${{ needs.publish-core-images.outputs.vela_core_digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  provenance-vela-cli:
+    name: Generate Provenance for Vela CLI
+    needs: publish-core-images
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # has to be sem var
+    with:
+      image: ${{ needs.publish-core-images.outputs.vela_cli_image }}
+      digest: ${{ needs.publish-core-images.outputs.vela_cli_digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,16 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
-  workflow_dispatch: { }
+      - 'v*'
+  workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
-  build:
+  goreleaser:
+    name: goreleaser
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       actions: read
@@ -20,27 +22,46 @@ jobs:
       pull-requests: read
       repository-projects: read
       statuses: read
-    runs-on: ubuntu-22.04
-    name: goreleaser
+      id-token: write
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
         with:
           fetch-depth: 0
-      - run: git fetch --force --tags
+
+      - name: Get Git tags
+        run: git fetch --force --tags
+
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: 1.22
           cache: true
-      - uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           distribution: goreleaser
           version: 1.14.1
           args: release --rm-dist --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate hashes
+        id: hash
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          HASHES=$(find dist -type f -exec sha256sum {} \; | base64 -w0)
+          echo "hashes=$HASHES" >> "$GITHUB_OUTPUT"
+
   upload-plugin-homebrew:
+    name: upload-sha256sums
+    needs: goreleaser
+    runs-on: ubuntu-22.04
+    if: ${{ !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc') }}
     permissions:
       contents: write
       actions: read
@@ -50,10 +71,6 @@ jobs:
       pull-requests: read
       repository-projects: read
       statuses: read
-    needs: build
-    runs-on: ubuntu-22.04
-    if: ${{ !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc') }}
-    name: upload-sha256sums
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
@@ -67,3 +84,16 @@ jobs:
           tag: ${{ github.ref }}
           revision: ${{ github.sha }}
           force: false
+
+  provenance-vela-bins:
+    name: generate provenance for binaries
+    needs: [goreleaser]
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # has to be sem var
+    with:
+      base64-subjects: '${{ needs.goreleaser.outputs.hashes }}'
+      upload-assets: true


### PR DESCRIPTION
### Description of your changes

copilot:all

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SLSA provenance generation for container images and release binaries to improve supply chain integrity. Attestations are created on tag builds and uploaded with releases.

- **New Features**
  - Container images: Generates SLSA v3 provenance for Vela Core and Vela CLI using `slsa-framework/slsa-github-generator` `generator_container_slsa3`. Uses image/digest from the publish job and OIDC (`id-token: write`).
  - Binaries: Generates SLSA v3 provenance for release artifacts using `generator_generic_slsa3`, with base64-encoded SHA256 subjects from GoReleaser outputs, and uploads them as release assets.

- **Refactors**
  - Split and renamed jobs; clearer step names and outputs. Added digest collection via `imjasonh/setup-crane`.
  - Ensured minimal permissions and OIDC where required. Provenance jobs run only on `refs/tags/*`. Homebrew upload remains gated for stable tags.

<sup>Written for commit 4910bb840d7e19e879f8af45b03da9cc05db5153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/roguepikachu/kubevela/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated provenance generation for container images and release binaries.
  * Added SHA-256 hash generation for release artifacts.
  * Expanded release automation to support tagged releases and manual runs.
  * Improved publishing workflows for container images across supported registries.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->